### PR TITLE
Outlines: Sprint 2 — OpenClaw Architecture + AI Assistants vs Agents

### DIFF
--- a/content/drafts/ai-assistants-vs-agents.md
+++ b/content/drafts/ai-assistants-vs-agents.md
@@ -1,0 +1,128 @@
+# AI Assistants vs. AI Agents: What's the Difference?
+
+**Type:** Explainer | **Area:** AI Assistants / AI Agents | **Writer:** Writer 1
+**Status:** 📋 Outline (pending editor review)
+**Target date:** 2026-04-24
+
+---
+
+## Outline
+
+### Introduction (2-3 sentences)
+"AI assistant" and "AI agent" get used interchangeably — but they describe meaningfully different things. This article draws a clear line between the two, explains why the distinction matters for developers, and helps you figure out which one you actually need.
+
+### Target Audience
+Developers who've used AI coding assistants (Copilot, Cursor, etc.) and are hearing more about "AI agents" but aren't sure where assistants end and agents begin. No prior knowledge of agent architectures needed — that's what Writer 2's article covers.
+
+### Scope
+**In scope:** Clear definitions of both terms, the spectrum between them, key architectural differences, practical examples of each, when to use which, and how they can work together.
+
+**Out of scope:** Deep agent architecture patterns (covered in Writer 2's articles), building agents from scratch, specific product comparisons/reviews. This is conceptual — it helps readers build a mental model.
+
+### Overlap Check
+- **Editor's "AI Coding Assistants" article:** Covers how to use assistants effectively. My article defines what an assistant *is* vs. what an agent *is* — complementary, not overlapping. I'll reference the editor's article as "for more on getting value from assistants."
+- **Writer 2's "What Are AI Agents?" article:** Covers agents in depth — what they are, how they work, the landscape. My article is the bridge between the two worlds. I'll reference Writer 2's article as "for a deeper dive on agents."
+- **My "Getting Started with OpenClaw" tutorial:** OpenClaw is an example of agent infrastructure. I'll reference it as a concrete example without repeating setup instructions.
+
+### Key Sections
+
+#### 1. The Short Answer
+Give the quick version upfront so busy readers get value immediately:
+- **AI assistant:** responds to your requests, one turn at a time. You drive; it helps.
+- **AI agent:** pursues goals across multiple steps, using tools and making decisions. It drives; you supervise.
+- Most real products fall on a spectrum between pure assistant and fully autonomous agent.
+
+#### 2. What Is an AI Assistant?
+- Definition: a tool that responds to prompts with generated output (text, code, images)
+- Key characteristics:
+  - **Reactive:** waits for you to ask, then responds
+  - **Single-turn or short-context:** each interaction is relatively self-contained
+  - **Human-directed:** you decide what to do next, the assistant helps you do it
+  - **No persistent goals:** it doesn't remember tasks or pursue objectives between sessions
+- Examples: GitHub Copilot (autocomplete), ChatGPT (conversational), AI code review tools
+- The mental model: a very capable collaborator sitting next to you
+
+#### 3. What Is an AI Agent?
+- Definition: a system that can pursue goals autonomously, using tools, making decisions, and operating over multiple steps
+- Key characteristics:
+  - **Proactive:** can initiate actions, not just respond
+  - **Multi-step:** breaks goals into tasks and executes them sequentially
+  - **Tool-using:** can read files, run code, call APIs, search the web, send messages
+  - **Persistent:** maintains state, memory, and context across sessions
+  - **Goal-directed:** works toward an objective, not just answering a question
+- Examples: AI coding agents that implement features end-to-end, AI assistants with tool use (like OpenClaw's Pi), automated code review bots that open PRs
+- The mental model: a junior developer you can delegate tasks to
+
+#### 4. The Spectrum (Not a Binary)
+- It's not assistant OR agent — most products sit on a spectrum
+- Diagram: spectrum from pure assistant → assistant with tools → agent with human oversight → fully autonomous agent
+- Examples at each point:
+  - **Pure assistant:** autocomplete, single-turn Q&A
+  - **Assistant with tools:** ChatGPT with code interpreter, Cursor with codebase context
+  - **Agent with oversight:** OpenClaw (autonomous but within guardrails), Devin-style coding agents
+  - **Fully autonomous:** CI/CD pipelines triggered by AI, background monitoring agents
+- The trend: products are moving rightward on the spectrum as models get more capable
+
+#### 5. Key Differences (Side by Side)
+Table comparing assistants and agents across dimensions:
+- **Control flow:** Human-driven vs. agent-driven
+- **Interaction pattern:** Request-response vs. goal-delegation
+- **Tool use:** None or limited vs. extensive
+- **Persistence:** Stateless or session-scoped vs. long-lived state and memory
+- **Autonomy:** Low (you decide next steps) vs. high (it decides next steps)
+- **Error handling:** Shows you the error vs. attempts to recover and retry
+- **Scope:** Single task vs. multi-step workflow
+
+#### 6. When to Use Each
+Practical guidance for developers:
+
+**Use an assistant when:**
+- The task is well-defined and you know the approach
+- You want to stay in the loop on every decision
+- Speed matters more than autonomy (boilerplate, tests, refactoring)
+- The cost of a mistake is high and you want to review before action
+
+**Use an agent when:**
+- The task involves multiple steps across different tools
+- You want to delegate and come back to a result
+- The task is repeatable and can be specified as a goal
+- You need the AI to operate when you're not actively watching (monitoring, scheduled tasks)
+
+**Use both together:**
+- Agent handles the multi-step workflow, you review outputs
+- Assistant helps you craft the prompts and review the agent's work
+- Agent runs in the background, assistant helps you interact with the results
+
+#### 7. What This Means for How You Build
+- If you're building tools for developers: understand where your product sits on the spectrum
+- If you're adopting AI tools: match the tool to the task (don't use an agent for autocomplete, don't use an assistant for multi-step automation)
+- The infrastructure difference: assistants need an API call; agents need a runtime (session management, tool execution, state persistence, error recovery)
+- OpenClaw as a concrete example: it's agent infrastructure — the Gateway, sessions, tools, and multi-channel routing are what make "just an LLM" into an agent
+
+#### 8. Where It's All Heading
+- Models are getting better at tool use and multi-step reasoning → the agent side of the spectrum is expanding
+- Assistants aren't going away — they're the interface layer for many agent systems
+- The distinction matters less as products converge, but the underlying architecture differences remain
+- For developers: invest in understanding both, because the tools you build with will increasingly blur the line
+
+#### 9. Summary
+- Assistants respond; agents pursue goals
+- Most products are on a spectrum between the two
+- Match the tool to the task
+- The architecture under the hood is what really differs
+
+---
+
+## Sources
+- Editor's article: "How to Actually Get Value from AI Coding Assistants"
+- Writer 2's article: "What Are AI Agents? A Developer's Guide"
+- OpenClaw docs (agent runtime, multi-agent routing, session management)
+- General AI agent/assistant industry knowledge
+
+## Notes for Editor
+- This is the "bridge" article between the editor's assistant piece and Writer 2's agent piece
+- Estimated 2,500-3,000 words — conceptual, no code examples needed
+- The spectrum diagram (Section 4) is the centerpiece — will need a visual
+- Cross-references both existing Sprint 1 articles without duplicating their content
+- This could work as the first article a reader encounters, even before the others
+- Open question: should this include a brief "glossary" sidebar defining LLM, tool use, RAG, etc.?

--- a/content/drafts/openclaw-architecture.md
+++ b/content/drafts/openclaw-architecture.md
@@ -1,0 +1,131 @@
+# OpenClaw Architecture: How It Works Under the Hood
+
+**Type:** Reference | **Area:** OpenClaw | **Writer:** Writer 1
+**Status:** 📋 Outline (pending editor review)
+**Target date:** 2026-04-24
+
+---
+
+## Outline
+
+### Introduction (2-3 sentences)
+You've installed OpenClaw and sent your first message. Now you want to know what's actually happening behind the scenes. This article breaks down the Gateway architecture — the components, the protocol, the session model, and how everything connects.
+
+### Target Audience
+Developers who've completed the "Getting Started" tutorial (or equivalent) and want to understand OpenClaw's internals. They can read code, understand client-server architecture, and want to know how the pieces fit together before building on top of it.
+
+### Scope
+**In scope:** Gateway as the central hub, WebSocket protocol, client types (operators vs. nodes), connection lifecycle, session management, channel routing, pairing/trust model, configuration structure, and remote access patterns.
+
+**Out of scope:** Multi-agent routing details (gets its own section but links to full docs), building custom skills/workflows, mobile node internals, deployment guides (Docker, Kubernetes, cloud). These get "learn more" links.
+
+### Key Sections
+
+#### 1. The Big Picture
+- OpenClaw is a single long-lived Gateway process that owns all messaging surfaces
+- High-level diagram: channels → Gateway → agent, with clients and nodes connecting via WebSocket
+- One Gateway per host — it's the single source of truth for sessions, routing, and connections
+- Compare to familiar patterns: reverse proxy for AI (messages in, responses out)
+
+#### 2. Components
+Walk through each component with its role:
+
+- **Gateway (daemon)** — the core process. Maintains channel connections, exposes the WebSocket API, validates frames, emits events. This is the hub everything connects to.
+- **Channels** — WhatsApp (Baileys), Telegram (grammY), Discord, iMessage, Signal, Slack, etc. Each is a provider connection the Gateway maintains. Messages flow in from channels, responses flow back out.
+- **Agent (Pi)** — the AI runtime. Receives routed messages, processes them with tools, returns responses. Runs in RPC mode with tool streaming.
+- **Clients (operator role)** — macOS app, CLI, web Control UI, automations. Connect via WebSocket, send requests, subscribe to events.
+- **Nodes (node role)** — iOS, Android, macOS, headless devices. Connect via WebSocket with explicit capabilities and commands (camera, screen recording, location, Canvas).
+- **WebChat / Control UI** — static browser UI that uses the Gateway WebSocket API. No separate server needed.
+
+#### 3. The WebSocket Protocol
+- Transport: WebSocket, text frames with JSON payloads
+- Handshake: first frame must be `connect` with role, scopes, capabilities, and auth
+- Request/response pattern: `{type:"req"} → {type:"res"}`
+- Server-push events: `{type:"event"}` for streaming, presence, health, etc.
+- Idempotency keys for side-effecting methods (send, agent) — safe retries
+- Protocol versioning: `minProtocol`/`maxProtocol` negotiation
+- Mermaid sequence diagram: connect → hello-ok → agent request → streaming events → final response
+
+#### 4. Connection Lifecycle
+- Device identity on connect (all clients and nodes)
+- Challenge-response: Gateway sends nonce, client signs it
+- Pairing approval for new devices
+- Local trust: loopback/tailnet connections can auto-approve
+- Device token issued after first approval — used for subsequent connects
+- Signature v3 binds platform + deviceFamily; metadata changes require re-pairing
+
+#### 5. Sessions: How Conversations Work
+- Direct chats collapse to a single main session per agent (`agent:<agentId>:main`)
+- Group chats get isolated session keys
+- `dmScope` controls DM isolation: `main`, `per-peer`, `per-channel-peer`, `per-account-channel-peer`
+- Security implications: why `per-channel-peer` matters for multi-user setups
+- Session state is owned by the Gateway (clients query, not read local files)
+- Identity links: mapping the same person across channels to one session
+
+#### 6. Channel Routing
+- How inbound messages get from a channel to the right agent
+- Channel-specific handlers (Baileys for WhatsApp, grammY for Telegram, etc.)
+- Group chat activation: mention patterns, require-mention settings
+- Access control: allowlists, pairing policies (`dmPolicy`), group policies
+- Multi-account support: multiple WhatsApp numbers, multiple Telegram bots, all in one Gateway
+
+#### 7. The Agent Runtime
+- Pi in RPC mode with tool streaming
+- Workspace contract: AGENTS.md, SOUL.md, USER.md, TOOLS.md, BOOTSTRAP.md, IDENTITY.md
+- Bootstrap file injection on session start
+- Built-in tools (read, write, exec, edit) plus skills
+- Tool policy and sandboxing
+
+#### 8. Configuration Architecture
+- Config file: `~/.openclaw/openclaw.json` (JSON5)
+- Safe defaults if missing
+- Four ways to edit: wizard, CLI one-liners, Control UI, direct edit
+- Hot reload: Gateway watches the file and applies changes
+- Environment variable overrides: `OPENCLAW_HOME`, `OPENCLAW_STATE_DIR`, `OPENCLAW_CONFIG_PATH`
+- Key config sections: channels, agents, session, messages, gateway, tools
+
+#### 9. Security Model
+- Personal assistant trust model: one trusted operator boundary per gateway
+- Gateway auth: tokens protect the WebSocket API
+- Device pairing: challenge-response + approval
+- Channel access control: allowlists, pairing, group policies
+- Not a multi-tenant security boundary — separate gateways for separate trust domains
+- `openclaw security audit` for checking your setup
+
+#### 10. Remote Access
+- Preferred: Tailscale or VPN
+- Alternative: SSH tunnel (`ssh -N -L 18789:...`)
+- Same handshake + auth over the tunnel
+- TLS + optional certificate pinning for production setups
+
+#### 11. Multi-Agent Routing (Overview)
+- Brief overview: multiple isolated agents in one Gateway
+- Each agent has its own workspace, state directory, session store, and auth profiles
+- Bindings route inbound messages to the right agent
+- `openclaw agents add <name>` to create new agents
+- Link to full multi-agent routing docs for details
+
+#### 12. What's Next
+- Link to multi-agent routing docs
+- Link to Gateway protocol reference
+- Link to configuration reference
+- Tease "Design Patterns for Reliable AI Agents" (Sprint 3)
+
+---
+
+## Sources
+- Architecture docs: `/opt/homebrew/lib/node_modules/openclaw/docs/concepts/architecture.md`
+- Protocol docs: `/opt/homebrew/lib/node_modules/openclaw/docs/gateway/protocol.md`
+- Session docs: `/opt/homebrew/lib/node_modules/openclaw/docs/concepts/session.md`
+- Multi-agent docs: `/opt/homebrew/lib/node_modules/openclaw/docs/concepts/multi-agent.md`
+- Security docs: `/opt/homebrew/lib/node_modules/openclaw/docs/gateway/security/index.md`
+- Agent runtime docs: `/opt/homebrew/lib/node_modules/openclaw/docs/concepts/agent.md`
+- Configuration docs: `/opt/homebrew/lib/node_modules/openclaw/docs/gateway/configuration.md`
+
+## Notes for Editor
+- This will be the longest article in the series — estimated 4,000-5,000 words
+- Heavy on diagrams: architecture overview, sequence diagrams, component map
+- Should include the mermaid connection lifecycle diagram from the protocol docs
+- Pairs directly with the "Getting Started" tutorial — readers are expected to have a running Gateway
+- The multi-agent section is intentionally brief — it's an overview that links to the full docs
+- May need to split "Configuration Architecture" into its own article if this runs too long


### PR DESCRIPTION
## Sprint 2 Outlines for Editor Review

**Writer:** Writer 1  
**Target date:** April 24, 2026  

---

### Article 1: OpenClaw Architecture: How It Works Under the Hood

**Type:** Reference | **Estimated:** 4,000–5,000 words

**Target audience:** Developers who've completed "Getting Started" and want to understand the internals before building on top of OpenClaw.

**Scope:**
- **In:** Gateway as central hub, WebSocket protocol, connection lifecycle, sessions, channel routing, agent runtime, configuration, security model, remote access, multi-agent overview
- **Out:** Deep multi-agent patterns, building custom skills, deployment guides (Docker/K8s/cloud)

**12 sections:** Big Picture → Components → WebSocket Protocol → Connection Lifecycle → Sessions → Channel Routing → Agent Runtime → Configuration → Security Model → Remote Access → Multi-Agent Overview → What's Next

**Key diagrams needed:** Architecture overview, connection sequence (mermaid), component map

---

### Article 2: AI Assistants vs. AI Agents: What's the Difference?

**Type:** Explainer | **Estimated:** 2,500–3,000 words

**Target audience:** Developers who've used AI coding assistants and are hearing about "agents" but aren't clear on the distinction.

**Scope:**
- **In:** Clear definitions, the spectrum between them, key differences, when to use which, what it means for builders
- **Out:** Deep agent architecture (Writer 2's territory), product reviews, building agents from scratch

**9 sections:** Short Answer → What Is an Assistant → What Is an Agent → The Spectrum → Side-by-Side Comparison → When to Use Each → What This Means for Building → Where It's Heading → Summary

**Key visual:** The assistant-to-agent spectrum diagram

### Overlap Check

- **Architecture article** follows directly from my "Getting Started" tutorial — readers go from setup to understanding
- **Assistants vs Agents** bridges the editor's assistant article and Writer 2's agent article — complementary, not duplicative
- Neither article overlaps with the new Leica/camera topics (issues #7-9)

### Open Questions

1. Architecture article may run long (5K+ words) — should it be split into two pieces (architecture + protocol deep-dive)?
2. For the Assistants vs Agents explainer — should I include a glossary sidebar (LLM, tool use, RAG, etc.)?
3. Diagrams: should I draft ASCII/mermaid versions in the PR, or wait for a design pass?