### PR TITLE
Writer 2: sprint 1 Patek outline drafts

### DIFF
--- a/SYSTEM/messages/communities/writing-team.md
+++ b/SYSTEM/messages/communities/writing-team.md
@@ -22,3 +22,35 @@ Team — new brief. We're writing about **Italian wines from Piedmont**. Target 
 **All work on GitHub:** https://github.com/Maximilien-ai/deep-agents-hack-mar27
 
 Previous issues closed. New Sprint 1 issues are live. Check your assignments.
+
+## 2026-04-06
+
+### [Editor] Kickoff — Patek Philippe for Collectors
+
+Team — new editorial direction is live.
+
+**Topic:** **Patek Philippe**
+**Audience:** **collectors**
+**Style baseline:** **Microsoft Style Guide**
+**Final format:** **HTML**
+
+We are not writing luxury-ad fluff. We are writing for readers who care about references, originality, provenance, service history, and whether a claim holds up under scrutiny.
+
+**Updated docs** (all in `content/`):
+- `style-guide.md` v4.0 — now aligned to Microsoft style and collector-focused watch coverage
+- `content-plan.md` — 6 assignments across 2 sprints
+- `publishing-calendar.md` — sprint dates, milestones, and publish targets
+
+**Sprint 1 assignments:**
+- **Writer 1** — *How to Read a Patek Philippe Reference Like a Collector*
+- **Writer 2** — *Buying Vintage Patek Philippe: Originality, Provenance, and the Red Flags That Matter*
+- **Writer 1** — *Which Patek Philippe Complications Matter Most to Collectors?*
+
+**Sprint 2 queued:**
+- *Calatrava, Nautilus, Aquanaut, Golden Ellipse: How the Core Families Fit a Serious Collection*
+- *Archive Extracts, Service History, and Condition: How to Evaluate a Patek Before You Buy*
+- *Modern Patek Philippe Collecting: Which References Are Overhyped, Underrated, and Actually Interesting?*
+
+**Repo:** https://github.com/Maximilien-ai/technical-writing
+
+Read the updated docs before drafting. If a claim cannot be sourced, do not write it like a fact.

--- a/SYSTEM/messages/groups/drafts.md
+++ b/SYSTEM/messages/groups/drafts.md
@@ -80,3 +80,33 @@ Reviewed the proposed Sprint 1 outlines against the current collector-focused co
 **First draft deadline for all three:** 2026-04-11
 
 Track work in GitHub issues #33, #34, and #35.
+
+## 2026-04-06
+
+### [Editor] Daily Draft Progress Check
+
+Current Sprint 1 status from the repo:
+
+- **#33 — Patek Philippe Reference Families Every Collector Should Know**
+  - Status: Outline approved
+  - Progress update: No writer draft-progress update posted yet
+  - Blockers: None reported
+
+- **#34 — Vintage vs. Modern Patek Philippe: How Collectors Should Think About the Tradeoffs**
+  - Status: Outline approved
+  - Progress update: No writer draft-progress update posted yet
+  - Blockers: None reported
+
+- **#35 — How to Evaluate Condition, Originality, and Provenance in a Patek Philippe Listing**
+  - Status: Outline approved
+  - Progress update: No writer draft-progress update posted yet
+  - Blockers: None reported
+
+**Pipeline note:** No completed first drafts have been submitted, so nothing moved to Review.
+
+**Priority adjustment:**
+1. #35 — Condition / originality / provenance
+2. #33 — Reference families
+3. #34 — Vintage vs. modern
+
+**Reminder:** First drafts are due 2026-04-11. If a writer hits a sourcing or scope problem, flag it directly on the GitHub issue.

--- a/SYSTEM/messages/groups/drafts.md
+++ b/SYSTEM/messages/groups/drafts.md
@@ -28,3 +28,32 @@ New topic. Read `content/style-guide.md` before writing a word — the wine-spec
 - GitHub: check your assigned issue
 
 **Process:** Branch → outline as draft PR → editor review → full draft → PR ready for review.
+
+## 2026-04-06
+
+### [Editor] Sprint 1 — Patek Philippe Assignments
+
+New brief. Read `content/style-guide.md` v4.0 before you draft anything. We are writing for collectors, not browsers and not brand worshippers.
+
+**Writer 1 — How to Read a Patek Philippe Reference Like a Collector**
+- Type: Explainer / Reference
+- Audience: Collectors who want a practical framework for decoding Patek references across eras
+- Goal: Explain how collectors parse a reference number, family, metal, generation, and configuration without turning the piece into a database dump
+- Scope: How reference numbers function, what can and cannot be inferred from them, how to cross-check catalog claims, and where collectors get tripped up
+- GitHub: check your assigned issue
+
+**Writer 2 — Buying Vintage Patek Philippe: Originality, Provenance, and the Red Flags That Matter**
+- Type: Buyer’s Guide
+- Audience: Collectors considering vintage Patek and trying to avoid expensive mistakes
+- Goal: Make the reader better at evaluating originality and provenance before bidding or buying
+- Scope: Dials, hands, polishing, caseback marks, movement matching, extracts, service replacement parts, dealer descriptions, and when to walk away
+- GitHub: check your assigned issue
+
+**Writer 1 — Which Patek Philippe Complications Matter Most to Collectors?**
+- Type: Deep Dive
+- Audience: Collectors deciding which complications are historically or practically meaningful rather than merely expensive
+- Goal: Compare complication categories through a collector lens instead of a prestige lens
+- Scope: Annual calendar, perpetual calendar, chronograph, split-seconds, world time, minute repeater; what matters historically, mechanically, and in the market
+- GitHub: check your assigned issue
+
+**Process:** Branch → outline as draft PR → editor review → full draft → PR ready for review.

--- a/SYSTEM/messages/groups/drafts.md
+++ b/SYSTEM/messages/groups/drafts.md
@@ -57,3 +57,26 @@ New brief. Read `content/style-guide.md` v4.0 before you draft anything. We are 
 - GitHub: check your assigned issue
 
 **Process:** Branch → outline as draft PR → editor review → full draft → PR ready for review.
+
+## 2026-04-06
+
+### [Editor] Outline Review — Sprint 1 Patek Assignments
+
+Reviewed the proposed Sprint 1 outlines against the current collector-focused content goals and existing published content.
+
+**Overlap check:** No meaningful overlap. The only published article in `content/published/` is about AI coding assistants.
+
+**Approved outlines**
+
+1. **Patek Philippe Reference Families Every Collector Should Know** (`content/drafts/patek-reference-families-outline.md`)
+   - Approved with direction to keep family vs. reference distinctions sharp and to avoid over-weighting Nautilus.
+
+2. **Vintage vs. Modern Patek Philippe: How Collectors Should Think About the Tradeoffs** (`content/drafts/patek-vintage-vs-modern-outline.md`)
+   - Approved with direction to give neo-vintage real weight and keep the piece grounded in collector tradeoffs.
+
+3. **How to Evaluate Condition, Originality, and Provenance in a Patek Philippe Listing** (`content/drafts/patek-condition-originality-provenance-outline.md`)
+   - Approved with direction to keep the evidence limits clear and make the checklist genuinely usable.
+
+**First draft deadline for all three:** 2026-04-11
+
+Track work in GitHub issues #33, #34, and #35.

--- a/SYSTEM/messages/groups/review.md
+++ b/SYSTEM/messages/groups/review.md
@@ -23,3 +23,54 @@ Reviewer — new topic, updated expectations. We're writing for wine snobs about
 **The bar:** Would a sommelier at a Barolo tasting find anything wrong? If yes, it's not ready.
 
 Style guide: `content/style-guide.md` v3.0. Know it.
+
+## 2026-04-06
+
+### [Editor] Review Standards — Patek Philippe Coverage
+
+Reviewer — new subject, new failure modes. We are writing for collectors, which means we get punished for vagueness, mythology, and sloppy watch facts.
+
+**What to check on every piece:**
+
+1. **Reference and caliber accuracy** — Verify every reference number, movement caliber, complication description, and production-era claim.
+2. **Originality claims** — Separate original parts from period-correct replacements, service replacements, and later modifications. Do not let writers blur those categories.
+3. **Provenance and paperwork** — Confirm what an Extract from the Archives can prove, what service papers can prove, and what they cannot prove.
+4. **Condition language** — Flag euphemisms. "Honest wear," "light polish," and "crisp case" should mean something concrete or be rewritten.
+5. **Market claims** — Require dates, sources, or a time window for auction and pricing claims. No timeless statements about value.
+6. **Collector usefulness** — Every piece should help the reader evaluate, compare, or understand a watch better. Cut brochure language.
+7. **Style guide compliance** — Microsoft style principles, clear headings, valid HTML, direct language, no luxury cliches.
+
+**Review format:** Blocker / Suggestion / Nit
+**Verdict:** ✅ Approved | 🔄 Needs Revision | ❌ Major Rewrite
+**Turnaround:** 2 days
+
+**The bar:** Would a serious Patek collector trust this piece enough to use it while evaluating a watch? If not, it is not ready.
+
+Style guide: `content/style-guide.md` v4.0. Use it.
+
+## 2026-04-06
+
+### [Editor] Review brief — Patek Philippe collector content
+
+Reviewer — updated standards for the new series.
+
+We are writing for **collectors**, not casual luxury readers. That means weak sourcing, fuzzy reference language, and inflated market claims are blockers.
+
+**What to check on every piece:**
+
+1. **Reference accuracy** — Are reference numbers, family names, movement names, and complication names correct and matched to the right watch?
+2. **Chronology** — Are launch eras, production periods, discontinuations, and archive-related statements supportable?
+3. **Condition language** — Are terms like *original dial*, *refinished*, *relumed*, *polished*, *restored*, and *service replacement* used correctly?
+4. **Provenance and papers** — Does the draft avoid implying that papers or an extract alone prove originality or authenticity?
+5. **Market claims** — Any pricing, demand, rarity, or auction-performance claim must be sourced and time-bound.
+6. **Collector usefulness** — Does the piece actually help a collector assess a watch, a listing, or a collecting strategy?
+7. **Style compliance** — Check against `content/style-guide.md` v4.0 and the Microsoft Style Guide baseline.
+8. **HTML readiness** — Structure should translate cleanly into publishable HTML without muddy hierarchy or formatting hacks.
+
+**Review format:** Blocker / Suggestion / Nit
+**Verdict:** ✅ Approved | 🔄 Needs Revision | ❌ Major Rewrite
+**Turnaround:** 2 days
+
+**The bar:** Would a serious Patek collector flag this as sloppy, imprecise, or oversold? If yes, it is not ready.
+
+Style guide: `content/style-guide.md` v4.0

--- a/SYSTEM/messages/groups/status.md
+++ b/SYSTEM/messages/groups/status.md
@@ -92,3 +92,26 @@ New series is set: **Patek Philippe for collectors**.
 **Repo:** https://github.com/Maximilien-ai/technical-writing
 
 Calendar source of truth: `content/publishing-calendar.md`
+
+## 2026-04-06
+
+### [Editor] Pipeline Status — Daily Draft Progress
+
+**Sprint 1 active issues:** #33, #34, #35
+
+**Current pipeline state**
+- 3 outlines approved
+- 0 first drafts submitted
+- 0 drafts moved to Review
+- 0 blockers formally reported
+
+**Priority order**
+1. #35 — Condition / originality / provenance
+2. #33 — Reference families
+3. #34 — Vintage vs. modern
+
+**Risk to watch:** Writers have approved outlines, but no draft-progress updates have been posted yet.
+
+**Next deadline:** First drafts due 2026-04-11
+
+Repo activity is being tracked in GitHub and PR #52.

--- a/SYSTEM/messages/groups/status.md
+++ b/SYSTEM/messages/groups/status.md
@@ -27,3 +27,68 @@ Topic pivot. All previous issues closed. New series: **Italian Wines from Piedmo
 **All work on GitHub:** https://github.com/Maximilien-ai/deep-agents-hack-mar27
 
 Full details: `content/publishing-calendar.md`
+
+## 2026-04-06
+
+### [Editor] New Content Direction — Patek Philippe
+
+Topic pivot. We are now publishing a **Patek Philippe** series for **collectors**.
+
+**Sprint 1 — Target: 2026-04-17**
+
+| Article | Writer | Status |
+|---------|--------|--------|
+| How to Read a Patek Philippe Reference Like a Collector | Writer 1 | 📝 Assigned |
+| Buying Vintage Patek Philippe: Originality, Provenance, and the Red Flags That Matter | Writer 2 | 📝 Assigned |
+| Which Patek Philippe Complications Matter Most to Collectors? | Writer 1 | 📝 Assigned |
+
+**Sprint 2 — Target: 2026-05-01**
+
+| Article | Writer | Status |
+|---------|--------|--------|
+| Calatrava, Nautilus, Aquanaut, Golden Ellipse: How the Core Families Fit a Serious Collection | Writer 2 | ⏳ Queued |
+| Archive Extracts, Service History, and Condition: How to Evaluate a Patek Before You Buy | Writer 1 | ⏳ Queued |
+| Modern Patek Philippe Collecting: Which References Are Overhyped, Underrated, and Actually Interesting? | Writer 2 | ⏳ Queued |
+
+**Format:** HTML
+**Style baseline:** Microsoft Writing Style Guide
+**Repo:** https://github.com/Maximilien-ai/technical-writing
+
+Full details: `content/publishing-calendar.md`
+
+## 2026-04-06
+
+### [Editor] Initial publishing schedule — Patek Philippe collector series
+
+New series is set: **Patek Philippe for collectors**.
+
+**Sprint 1 — Target publish date: 2026-04-17**
+
+| Article | Writer | Status |
+|---------|--------|--------|
+| Patek Philippe Reference Families Every Collector Should Know | Writer 1 | 📝 Assigned |
+| Vintage vs. Modern Patek Philippe: How Collectors Should Think About the Tradeoffs | Writer 2 | 📝 Assigned |
+| How to Evaluate Condition, Originality, and Provenance in a Patek Philippe Listing | Writer 1 | 📝 Assigned |
+
+**Sprint 2 — Target publish date: 2026-05-01**
+
+| Article | Writer | Status |
+|---------|--------|--------|
+| Calatrava, Nautilus, Aquanaut, and Grand Complications: Where Each Fits in a Serious Collection | Writer 2 | ⏳ Queued |
+| Patek Philippe Papers, Extracts, and Service History: What They Confirm and What They Do Not | Writer 1 | ⏳ Queued |
+| Buying Patek Philippe at Auction: Catalog Language, Estimate Traps, and Bid Discipline | Writer 2 | ⏳ Queued |
+
+**Milestones**
+- 2026-04-08 — Sprint 1 outlines due
+- 2026-04-13 — Sprint 1 drafts due
+- 2026-04-15 — Sprint 1 review complete
+- 2026-04-17 — Sprint 1 publish target
+
+- 2026-04-22 — Sprint 2 outlines due
+- 2026-04-27 — Sprint 2 drafts due
+- 2026-04-29 — Sprint 2 review complete
+- 2026-05-01 — Sprint 2 publish target
+
+**Repo:** https://github.com/Maximilien-ai/technical-writing
+
+Calendar source of truth: `content/publishing-calendar.md`

--- a/content/content-plan.md
+++ b/content/content-plan.md
@@ -1,18 +1,26 @@
-# Content Plan — Italian Wines from Piedmont
+# Content Plan — Patek Philippe for Collectors
 
-**Owner:** Editor | **Created:** 2026-03-27
+**Owner:** Editor | **Created:** 2026-04-06 | **Output format:** HTML
 
 ## Mission
 
-Produce authoritative, opinionated content on Piedmontese wines for serious wine enthusiasts. Every piece should be accurate, sensory, and worth reading with a glass in hand.
+Produce precise, collector-grade editorial content on **Patek Philippe** for readers who care about references, movements, provenance, condition, service history, originality, and long-term collectibility. Every piece should be factual, specific, and useful to a collector making decisions.
 
 ## Target Audience
 
-Wine snobs — experienced enthusiasts who know their way around a wine list. They want depth, specificity, and a point of view. They can handle Italian terminology and don't need anyone to explain what tannin is.
+Collectors. Assume readers understand basic watch terminology and want substance rather than entry-level luxury marketing copy.
 
-## Topic Area
+## Editorial Direction
 
-**Italian Wines from Piedmont** — Barolo, Barbaresco, Barbera, Dolcetto, Langhe, Roero, the producers, the vineyards, the traditions, and the arguments.
+- **Primary topic:** Patek Philippe
+- **Audience lens:** collector decision-making
+- **Style guide:** Microsoft Style Guide principles adapted for watch journalism
+- **Output format:** HTML
+- **Editorial standard:** Clear, modern, factual, concise, and scannable
+
+## Existing Workspace Context
+
+The workspace already contained a prior editorial plan, publishing calendar, and style guide for a different topic area. Those files have now been repurposed for this Patek Philippe collector series.
 
 ---
 
@@ -20,39 +28,64 @@ Wine snobs — experienced enthusiasts who know their way around a wine list. Th
 
 ### Sprint 1 (Week 1-2)
 
-| # | Topic | Writer | Type |
-|---|-------|--------|------|
-| 1 | Barolo vs. Barbaresco: The Rivalry That Defines Piedmont | Writer 1 | Explainer |
-| 2 | The Nebbiolo Grape: A Difficult, Magnificent Obsession | Writer 2 | Deep Dive |
-| 3 | 10 Piedmont Producers Every Wine Snob Should Know | Writer 1 | Guide / List |
+| # | Topic | Writer | Type | Working Angle |
+|---|-------|--------|------|---------------|
+| 1 | Patek Philippe Collecting 101: How to Read References, Papers, Provenance, and Service History | Writer 1 | Collector Guide | Teach collectors how to evaluate a watch beyond the headline model name |
+| 2 | Nautilus, Aquanaut, Calatrava, or Complications: Which Patek Category Fits Which Collector? | Writer 2 | Comparative Guide | Match collecting goals to major Patek families without hype |
+| 3 | How to Evaluate Condition and Originality in Vintage and Neo-Vintage Patek Philippe Watches | Writer 1 | Deep Dive | Focus on polishing, dial swaps, replacement parts, lume, case geometry, and extractable provenance |
+| 4 | Buying Patek Philippe at Auction, Through Dealers, or Private Sale: Risk, Pricing, and Due Diligence | Writer 2 | Buying Guide | Compare channels and explain practical buyer safeguards |
 
 ### Sprint 2 (Week 3-4)
 
-| # | Topic | Writer | Type |
-|---|-------|--------|------|
-| 4 | The Barolo Cru Map: Why Vineyard Names Matter More Than You Think | Writer 2 | Reference / Analysis |
-| 5 | Barbera and Dolcetto: Piedmont's Underappreciated Everyday Wines | Writer 1 | Guide |
-| 6 | Vintage Guide: Which Piedmont Years Are Actually Worth Cellaring? | Writer 2 | Reference |
+| # | Topic | Writer | Type | Working Angle |
+|---|-------|--------|------|---------------|
+| 5 | The Patek Philippe Annual Calendar, Perpetual Calendar, and Chronograph: What Collectors Should Know Before Buying | Writer 1 | Technical Guide | Explain complication tiers in collector terms |
+| 6 | Why Box, Papers, Extracts, and Service Records Matter in the Patek Philippe Market | Writer 2 | Market Guide | Separate real value signals from overpaying for packaging |
 
 ## Content Pipeline
 
-```
-Outline → Editor Review → Draft → Fact Check → Revision → Publish
+```text
+Outline → Editor Review → Draft → Fact Check → Revision → Final Approval → Publish
 ```
 
 | Stage | Group | Owner |
 |-------|-------|-------|
-| Outline & Drafting | Drafts | Writers |
-| Outline Approval | Drafts | Editor |
-| Fact Check & Review | Review | Reviewer |
+| Topic assignment & outline | Drafts | Editor + Writers |
+| Drafting | Drafts | Writers |
+| Technical review & fact check | Review | Reviewer |
 | Revision | Drafts | Writers |
-| Final Approval | Review | Editor |
-| Publish | Publishing | Publisher |
+| Final editorial approval | Review | Editor |
+| HTML prep & publication | Publishing | Publisher |
 
-## Deadlines (per article)
+## Assignment Rules
 
-- Outline due: 2 days after assignment
-- First draft due: 5 days after outline approval
-- Review turnaround: 2 days
-- Revision turnaround: 2 days
-- Publication: 1 day after final approval
+- Writers submit **HTML-first drafts** with semantic structure (`<article>`, `<section>`, headings, lists, tables only when justified).
+- Every draft must include:
+  - working title
+  - 1-sentence SEO description
+  - target keyword/theme
+  - source list
+  - open fact-check questions
+- Avoid investment-advice framing. Use careful language around value retention, market behavior, and collectibility.
+- Separate verified facts from market interpretation.
+
+## Deadlines
+
+- Outline due: **2026-04-08**
+- First draft due: **2026-04-13**
+- Review turnaround: **2 business days**
+- Revision turnaround: **2 business days**
+- Publication target for Sprint 1: **2026-04-17 to 2026-04-24**
+- Sprint 2 outlines due: **2026-04-20**
+
+## Writer Assignments Summary
+
+### Writer 1
+- Patek Philippe Collecting 101: How to Read References, Papers, Provenance, and Service History
+- How to Evaluate Condition and Originality in Vintage and Neo-Vintage Patek Philippe Watches
+- The Patek Philippe Annual Calendar, Perpetual Calendar, and Chronograph: What Collectors Should Know Before Buying
+
+### Writer 2
+- Nautilus, Aquanaut, Calatrava, or Complications: Which Patek Category Fits Which Collector?
+- Buying Patek Philippe at Auction, Through Dealers, or Private Sale: Risk, Pricing, and Due Diligence
+- Why Box, Papers, Extracts, and Service Records Matter in the Patek Philippe Market

--- a/content/drafts/patek-buying-channels-outline.md
+++ b/content/drafts/patek-buying-channels-outline.md
@@ -1,0 +1,63 @@
+# Outline — Buying Patek Philippe at Auction, Through Dealers, or Private Sale: Risk, Pricing, and Due Diligence
+
+**Issue:** #54  
+**Status:** Proposed for editorial review  
+**Format:** HTML article  
+**Target draft deadline (proposed):** 2026-04-13
+
+## Target audience
+
+Collectors comparing buying channels for a Patek Philippe watch and trying to understand where each channel provides useful evidence, where it introduces risk, and how much diligence they need to do themselves.
+
+## Scope
+
+**In scope**
+- Auction, dealer, and private-sale tradeoffs
+- Catalog language, estimates, buyer's premium, warranty/return structure, and visibility into condition and provenance
+- How channel choice changes diligence, negotiation leverage, and post-sale recourse
+- Practical safeguards before bidding or buying
+
+**Out of scope**
+- Model-specific authentication guides
+- Full legal treatment of title disputes or fraud recovery
+- General market-investment advice
+- Exhaustive venue-by-venue review of every auction house or dealer
+
+## Key sections
+
+1. **Introduction — The watch matters, but the channel changes the risk**
+   Set up channel selection as part of collecting discipline, not just convenience.
+
+2. **What each buying channel is really selling you**
+   Explain the practical differences in evidence, speed, trust, and accountability.
+
+3. **Auction — access, price discovery, and catalog-language traps**
+   Cover estimates, buyer's premium, previews, limited recourse, and why excitement distorts judgment.
+
+4. **Dealer — curation, relationship value, and markup for reduced friction**
+   Explain when dealer premium may buy useful screening and when it merely buys presentation.
+
+5. **Private sale — flexibility, opacity, and asymmetric information**
+   Show where private deals can be attractive and where they become dangerous.
+
+6. **Condition, originality, and provenance across channels**
+   Compare how much evidence typically appears in each channel and what still needs independent verification.
+
+7. **Due diligence checklist before money moves**
+   Build a practical sequence: reference confirmation, movement/case matching where possible, paperwork review, service history, recourse, and third-party inspection if needed.
+
+8. **Which collector should prefer which channel**
+   Match channel choice to experience level, risk tolerance, and the type of watch being pursued.
+
+9. **Conclusion — Pay for evidence and recourse, not just access**
+
+## Overlap check
+
+- **Published content:** No overlap with current published content.
+- **Existing draft content:** Related to `content/drafts/patek-condition-originality-provenance-outline.md`, but distinct in focus: this piece is about channel-specific risk and diligence rather than listing analysis alone.
+
+## Notes for editorial review
+
+- Keep the article practical, not romantic.
+- Separate pricing transparency from true value.
+- Avoid implying that any channel guarantees authenticity or originality.

--- a/content/drafts/patek-category-fit-outline.md
+++ b/content/drafts/patek-category-fit-outline.md
@@ -1,0 +1,63 @@
+# Outline — Nautilus, Aquanaut, Calatrava, or Complications? Which Patek Category Fits Which Collector?
+
+**Issue:** #53  
+**Status:** Proposed for editorial review  
+**Format:** HTML article  
+**Target draft deadline (proposed):** 2026-04-13
+
+## Target audience
+
+Collectors who already understand basic watch terminology and want a practical framework for deciding which broad Patek Philippe category actually fits their collecting priorities.
+
+## Scope
+
+**In scope**
+- The collector logic of Calatrava, Nautilus, Aquanaut, and complications
+- How wearability, service realities, originality risk, entry cost, and market distortion differ by category
+- Which collector profiles align with which category
+- How category choice should shape the next layer of research before shopping
+
+**Out of scope**
+- Exhaustive reference-by-reference recommendations
+- Investment promises or speculative pricing claims
+- Full authentication guidance for specific references
+- Deep movement history beyond what helps category-level decisions
+
+## Key sections
+
+1. **Introduction — Choose a category before you chase a reference**
+   Frame the article around collector fit rather than hype.
+
+2. **What category choice actually controls**
+   Explain how category affects wearing pattern, research burden, service expectations, originality risk, and budget exposure.
+
+3. **Calatrava — disciplined, design-led collecting**
+   Who it suits, what it rewards, and where collectors still get tripped up.
+
+4. **Nautilus — category-defining, high-noise collecting**
+   Why it matters, why hype distorts judgment, and what kind of collector can navigate that distortion.
+
+5. **Aquanaut — modern casual Patek with different tradeoffs**
+   Position it as its own collecting lane rather than a mere Nautilus substitute.
+
+6. **Complications — scholarship, mechanical interest, and higher consequence**
+   Explain why complications can be the richest category intellectually while also demanding more diligence.
+
+7. **Which collector profile fits which category**
+   Use clear collector types: daily wearer, design-first collector, market-aware buyer, technical enthusiast, long-horizon scholar.
+
+8. **A decision framework before shopping**
+   Give readers a checklist to choose a lane before they start browsing listings.
+
+9. **Conclusion — Buy into a collecting logic, not just a famous shape**
+
+## Overlap check
+
+- **Published content:** No overlap with the currently published AI coding assistants article.
+- **Existing draft content:** Minimal overlap with `content/drafts/patek-reference-families-outline.md`; this piece is about collector fit and category choice, not a family-by-family orientation map.
+
+## Notes for editorial review
+
+- Keep Aquanaut from being framed as a lesser Nautilus.
+- Avoid letting Nautilus dominate the piece simply because search demand is louder.
+- Make the collector-profile section concrete enough to be useful.

--- a/content/drafts/patek-condition-originality-provenance-outline.md
+++ b/content/drafts/patek-condition-originality-provenance-outline.md
@@ -1,0 +1,71 @@
+# Outline — How to Evaluate Condition, Originality, and Provenance in a Patek Philippe Listing
+
+**Issue:** #35  
+**Status:** Proposed for editorial review  
+**Format:** HTML article  
+**Target draft deadline (proposed):** 2026-04-11
+
+## Target audience
+
+Collectors reading dealer, auction, or private-sale listings for Patek Philippe watches and trying to separate persuasive language from meaningful evidence.
+
+## Scope
+
+**In scope**
+- The difference between condition, originality, and provenance
+- What listing language usually means versus what it should mean
+- Dials, hands, lume, polishing, case geometry, hallmarks, bracelets, movement checks, and paperwork
+- What an Extract from the Archives or service record can and cannot support
+- Practical red flags that should slow a buyer down or stop the purchase
+
+**Out of scope**
+- Full authentication guidance for every reference family
+- Legal disputes over title or ownership
+- Market-pricing guide by reference
+- Deep restoration philosophy beyond what helps a buyer read a listing
+
+## Key sections
+
+1. **Introduction — Three ideas collectors constantly blur together**
+   Set up condition, originality, and provenance as related but separate questions.
+
+2. **Condition is not originality**
+   Explain why a well-preserved watch and an all-original watch are not the same thing.
+
+3. **How to read dial, hand, and case language**
+   Translate common listing phrases into collector-risk questions.
+
+4. **Polishing, hallmarks, and case geometry**
+   Show what matters and why vague adjectives are not enough.
+
+5. **Movement and bracelet checks**
+   What can reasonably be verified from a listing and what cannot.
+
+6. **Papers, Extracts, and service history**
+   Clarify the evidentiary value and limits of each.
+
+7. **Red flags that deserve skepticism or a walk-away**
+   Build a practical checklist.
+
+8. **How much uncertainty a collector can tolerate**
+   Different collector types, different thresholds.
+
+9. **Conclusion — Buy evidence, not adjectives**
+
+## Overlap check
+
+- **Published content:** No overlap with the existing published AI coding assistants article.
+- **Existing draft content:** No overlap with current drafts on AI agents, OpenClaw, Leica, or wine.
+
+## Editor review
+
+**Alignment:** Very strong. This is exactly the kind of utility-first collector piece the series needs.
+
+**Feedback**
+- Keep the distinction between condition and originality painfully clear.
+- Avoid pretending a listing alone can authenticate a watch; emphasize limits.
+- The checklist section should be concrete enough that a reader could use it while shopping.
+- Make paperwork language cautious and evidence-based.
+
+**Approval:** Approved  
+**First draft due:** 2026-04-11

--- a/content/drafts/patek-reference-families-outline.md
+++ b/content/drafts/patek-reference-families-outline.md
@@ -1,0 +1,70 @@
+# Outline — Patek Philippe Reference Families Every Collector Should Know
+
+**Issue:** #33  
+**Status:** Proposed for editorial review  
+**Format:** HTML article  
+**Target draft deadline (proposed):** 2026-04-11
+
+## Target audience
+
+Collectors who already understand basic watch terminology and want a practical framework for understanding how Patek Philippe reference families map to collecting priorities. This is for readers choosing what to study, buy, or avoid — not for total beginners.
+
+## Scope
+
+**In scope**
+- Why family-level understanding matters before reference-level obsession
+- The collector roles of Calatrava, Nautilus, Aquanaut, Golden Ellipse, complicated dress watches, and grand complications
+- What each family signals in design, wearability, market behavior, and collector interest
+- How family identity affects what a collector should research next
+
+**Out of scope**
+- Exhaustive reference-by-reference cataloging
+- Price guides by individual reference
+- Deep movement history for every line
+- Auction strategy and buying-channel analysis
+
+## Key sections
+
+1. **Introduction — Start with the family, not the hype**
+   Why collectors get lost when they jump straight to famous references.
+
+2. **What "family" means in Patek Philippe collecting**
+   Distinguish family, reference, variant, and configuration.
+
+3. **Calatrava — the dress-watch baseline**
+   Why it matters, what kinds of collectors it suits, and where the traps are.
+
+4. **Nautilus — category-defining, overexposed, still important**
+   Why the family matters beyond market noise.
+
+5. **Aquanaut — modern casual collecting with different risks**
+   Position it against Nautilus without turning it into a lesser-copy argument.
+
+6. **Golden Ellipse — design-led collecting**
+   Explain why it matters historically and why many collectors overlook it.
+
+7. **Complicated and grand complication families**
+   How collectors should think about perpetual calendars, chronographs, world time, and higher complications at the family level.
+
+8. **How family choice shapes research and buying strategy**
+   What to verify next once a collector knows which lane they are in.
+
+9. **Conclusion — Build a collection logic before chasing references**
+
+## Overlap check
+
+- **Published content:** No meaningful overlap. The only published piece in `content/published/` is about AI coding assistants.
+- **Existing draft content:** No meaningful overlap with current drafts on AI agents, OpenClaw, Leica, or Piedmont wines.
+
+## Editor review
+
+**Alignment:** Strong. The outline is useful for collectors and gives the series a clean orientation piece without turning into a glossary.
+
+**Feedback**
+- Keep the family vs. reference distinction extremely clear in the first third of the piece.
+- Do not let Nautilus dominate the article just because it dominates search traffic.
+- Golden Ellipse needs a real argument, not a token section.
+- End with a concrete collector framework or checklist so the piece has practical utility.
+
+**Approval:** Approved  
+**First draft due:** 2026-04-11

--- a/content/drafts/patek-vintage-vs-modern-outline.md
+++ b/content/drafts/patek-vintage-vs-modern-outline.md
@@ -1,0 +1,70 @@
+# Outline — Vintage vs. Modern Patek Philippe: How Collectors Should Think About the Tradeoffs
+
+**Issue:** #34  
+**Status:** Proposed for editorial review  
+**Format:** HTML article  
+**Target draft deadline (proposed):** 2026-04-11
+
+## Target audience
+
+Collectors deciding whether to focus their time and money on vintage, neo-vintage, or modern Patek Philippe watches. The reader already understands basic watch terminology and wants a sharper framework for evaluating tradeoffs.
+
+## Scope
+
+**In scope**
+- Why collectors are drawn to vintage versus modern Patek
+- Design, case proportions, movement character, serviceability, originality risk, and wearability
+- Where neo-vintage fits between the two poles
+- How documentation, replacement parts, and market behavior affect the decision
+- What kind of collector profile fits each lane
+
+**Out of scope**
+- A full ranking of best references to buy
+- Pure investment advice
+- Detailed auction tactics
+- Authentication guidance by single model family
+
+## Key sections
+
+1. **Introduction — The choice is not old vs. new, but what kind of collecting you want**
+
+2. **What collectors are really choosing between**
+   Explain that this is about risk, romance, service realities, and use-case — not just age.
+
+3. **The vintage case**
+   Smaller proportions, historical interest, charm, rarity, and originality risk.
+
+4. **The modern case**
+   Convenience, documentation, service access, wearability, and market distortion.
+
+5. **Why neo-vintage deserves its own section**
+   Explain why this era is often the most interesting compromise.
+
+6. **Originality, service parts, and documentation**
+   Show how the same watch can look more or less attractive depending on collector priorities.
+
+7. **How different collector types should think about the tradeoff**
+   Wear-focused collector, scholarship-driven collector, market-aware collector, complication hunter.
+
+8. **A decision framework**
+   Provide a practical way to choose a lane before shopping.
+
+9. **Conclusion — Buy the compromises you can live with**
+
+## Overlap check
+
+- **Published content:** No overlap with published content; the only live article is about AI coding assistants.
+- **Existing draft content:** No overlap with current drafts on AI agents, OpenClaw, Leica, or wine.
+
+## Editor review
+
+**Alignment:** Good. This gives the series a framing piece for collectors who are still deciding where to focus.
+
+**Feedback**
+- Add neo-vintage early enough that it does not feel like an afterthought.
+- Keep the article grounded in collector tradeoffs, not generic lifestyle language.
+- Use examples sparingly and only when they clarify a pattern.
+- Make sure serviceability and replacement-part risk get real weight, not a passing mention.
+
+**Approval:** Approved  
+**First draft due:** 2026-04-11

--- a/content/publishing-calendar.md
+++ b/content/publishing-calendar.md
@@ -1,34 +1,42 @@
-# Publishing Calendar — Piedmont Wines Series
+# Publishing Calendar — Patek Philippe Collector Series
 
-**Owner:** Editor | **Last Updated:** 2026-03-27
+**Owner:** Editor | **Last Updated:** 2026-04-06
 
 ## Schedule
 
 | Week | Target Date | Article | Writer | Status |
 |------|-------------|---------|--------|--------|
-| 1-2 | 2026-04-10 | Barolo vs. Barbaresco: The Rivalry That Defines Piedmont | Writer 1 | 📝 Assigned |
-| 1-2 | 2026-04-10 | The Nebbiolo Grape: A Difficult, Magnificent Obsession | Writer 2 | 📝 Assigned |
-| 1-2 | 2026-04-10 | 10 Piedmont Producers Every Wine Snob Should Know | Writer 1 | 📝 Assigned |
-| 3-4 | 2026-04-24 | The Barolo Cru Map: Why Vineyard Names Matter More Than You Think | Writer 2 | ⏳ Queued |
-| 3-4 | 2026-04-24 | Barbera and Dolcetto: Piedmont's Underappreciated Everyday Wines | Writer 1 | ⏳ Queued |
-| 3-4 | 2026-04-24 | Vintage Guide: Which Piedmont Years Are Actually Worth Cellaring? | Writer 2 | ⏳ Queued |
+| 1 | 2026-04-08 | Patek Philippe Collecting 101: How to Read References, Papers, Provenance, and Service History | Writer 1 | 📝 Outline due |
+| 1 | 2026-04-08 | Nautilus, Aquanaut, Calatrava, or Complications: Which Patek Category Fits Which Collector? | Writer 2 | 📝 Outline due |
+| 1 | 2026-04-10 | How to Evaluate Condition and Originality in Vintage and Neo-Vintage Patek Philippe Watches | Writer 1 | 📝 Assigned |
+| 1 | 2026-04-10 | Buying Patek Philippe at Auction, Through Dealers, or Private Sale: Risk, Pricing, and Due Diligence | Writer 2 | 📝 Assigned |
+| 2 | 2026-04-17 | Patek Philippe Collecting 101: How to Read References, Papers, Provenance, and Service History | Writer 1 | ✏️ Draft target |
+| 2 | 2026-04-17 | Nautilus, Aquanaut, Calatrava, or Complications: Which Patek Category Fits Which Collector? | Writer 2 | ✏️ Draft target |
+| 2 | 2026-04-20 | How to Evaluate Condition and Originality in Vintage and Neo-Vintage Patek Philippe Watches | Writer 1 | ✏️ Draft target |
+| 2 | 2026-04-20 | Buying Patek Philippe at Auction, Through Dealers, or Private Sale: Risk, Pricing, and Due Diligence | Writer 2 | ✏️ Draft target |
+| 3 | 2026-04-24 | Patek Philippe Collecting 101: How to Read References, Papers, Provenance, and Service History | Writer 1 | 🚀 Publish target |
+| 3 | 2026-04-24 | Nautilus, Aquanaut, Calatrava, or Complications: Which Patek Category Fits Which Collector? | Writer 2 | 🚀 Publish target |
+| 4 | 2026-04-29 | The Patek Philippe Annual Calendar, Perpetual Calendar, and Chronograph: What Collectors Should Know Before Buying | Writer 1 | ⏳ Queued |
+| 4 | 2026-04-29 | Why Box, Papers, Extracts, and Service Records Matter in the Patek Philippe Market | Writer 2 | ⏳ Queued |
 
 ## Status Legend
 
-- 📝 Assigned — Writer has the topic, working on outline
-- ✏️ Drafting — Outline approved, first draft in progress
+- 📝 Assigned — Writer has the topic and is preparing outline or draft
+- ✏️ Draft target — Draft in progress or due
 - 🔍 In Review — With reviewer for fact-checking
 - 🔄 Revision — Writer addressing review feedback
-- ✅ Approved — Ready for publishing
-- 🚀 Published — Live
+- ✅ Approved — Cleared for publishing
+- 🚀 Publish target — Planned release date
+- ⏳ Queued — Planned but not yet started
 
-## Previously Published
+## Editorial Cadence
 
-| Article | Area | Status |
-|---------|------|--------|
-| How to Actually Get Value from AI Coding Assistants | AI Assistants | 🚀 Published |
+- **Target:** 2 publishable articles per week after ramp-up
+- **Review rhythm:** Reviewer gets articles in staggered batches, not all at once
+- **Status update cadence:** Post schedule changes and blockers in the Status group
 
-## Cadence
+## Scheduling Notes
 
-- **Target:** 3 articles per 2-week sprint
-- **Pipeline review:** Weekly in Status group
+- Sprint 1 is designed to establish core collector utility: evaluation, category selection, condition, and buying process.
+- Sprint 2 deepens technical and market-supporting topics.
+- Publication order should favor evergreen utility pieces before narrower complication-specific articles.

--- a/content/reviewer-brief.md
+++ b/content/reviewer-brief.md
@@ -1,0 +1,62 @@
+# Reviewer Brief — Patek Philippe Collector Series
+
+**From:** Editor  
+**To:** Reviewer  
+**Date:** 2026-04-06
+
+## What matters most
+
+This series is for collectors. Accuracy matters at the level of references, calibers, originality, provenance language, service implications, and market framing. Review with a bias toward precision over elegance whenever the two conflict.
+
+## Review priorities
+
+1. **Reference and caliber accuracy**
+   - Verify reference numbers, movement calibers, complication descriptions, and production-era claims.
+   - Flag soft claims that sound plausible but are not properly sourced.
+
+2. **Originality and condition language**
+   - Distinguish original parts from period-correct replacements, service replacements, and later modifications.
+   - Push back on fuzzy wording like *crisp*, *honest*, *untouched*, or *sharp* unless the text explains what that means.
+
+3. **Provenance and paperwork**
+   - Confirm what an Extract from the Archives can prove, what service papers can prove, and what they cannot prove.
+   - Do not let writers imply authenticity or originality beyond the evidence.
+
+4. **Market framing**
+   - Require a date, source, or time window for pricing and auction commentary.
+   - Rewrite broad investment language into grounded collector analysis.
+
+5. **Source quality**
+   - Prefer official brand references, auction catalogs/results, and reputable specialist sources.
+   - Ask for stronger sourcing when a claim leans on forum consensus or dealer copy.
+
+6. **HTML and structure sanity check**
+   - Confirm drafts are publishable as HTML and not markdown wearing HTML clothing.
+   - Check heading hierarchy, links, lists, and tables for usability.
+
+## Fact-check expectations
+
+- Highlight any claim that cannot be supported from the cited source.
+- Distinguish between verified facts and market interpretation.
+- Note when dates, configurations, or production details vary across sources.
+- If a claim is widely repeated but weakly documented, recommend a rewrite rather than letting it stand.
+
+## Escalate immediately if you see
+
+- Claims that a watch is authentic or original without enough evidence
+- Unsupported market-value promises
+- Reference/caliber mismatches
+- Auction anecdotes presented as broad market truth
+- HTML that will create avoidable publishing cleanup
+
+## Review output format
+
+For each draft, provide:
+
+- **Accuracy verdict:** pass / revise / high-risk
+- **Top factual corrections:** bullet list
+- **Source gaps:** bullet list
+- **Collector-risk phrasing to soften:** bullet list
+- **HTML or structure issues:** bullet list
+
+If a piece is mostly strong but has two or three dangerous sentences, call that out directly. Those are the mistakes most likely to damage trust.

--- a/content/style-guide.md
+++ b/content/style-guide.md
@@ -1,65 +1,114 @@
 # Writing Style Guide
 
-**Owner:** Editor | **Version:** 3.0 | **Last Updated:** 2026-03-27
+**Owner:** Editor | **Version:** 4.0 | **Last Updated:** 2026-04-06
 
 ## Audience
 
-Wine snobs. These readers know their Sangiovese from their Syrah. They've been to tastings, they have opinions about vintages, and they can smell marketing from across the room. Don't patronize them — but don't gatekeep either. Write for the enthusiast who wants depth, not the sommelier trying to impress other sommeliers.
+Collectors. Write for readers who already know what a reference number is, understand basic mechanical-watch vocabulary, and care about condition, provenance, originality, service history, and market context.
 
-## Voice & Tone
+## Standard
 
-- **College-level.** Educated, literate, not academic. Assume intelligence, don't assume a wine degree.
-- **Confident and opinionated.** Have a point of view. "This is a great Barolo" is better than "many consider this a well-regarded wine."
-- **Sensory and precise.** Wine writing lives or dies on specificity. "Notes of tar, dried rose, and leather" beats "complex and interesting."
-- **Active voice** by default. Passive for emphasis or when the actor is irrelevant.
-- **Present tense** for describing wines and regions. Past tense for historical context.
-- **No purple prose.** Evocative, yes. Overwrought, no. Piedmont deserves better than "a symphony of flavors dancing on the palate."
+Follow the **Microsoft Style Guide** spirit:
+
+- Be clear first.
+- Prefer plain language over prestige fluff.
+- Use active voice unless passive is clearer.
+- Front-load useful information.
+- Keep sentences controlled and readable.
+- Use consistent terminology.
+- Respect the reader's time.
+
+## Voice and Tone
+
+- **Authoritative, not breathless.** Avoid luxury-brand worship.
+- **Specific, not vague.** Name references, movements, eras, and trade-offs when known.
+- **Collector-minded.** Emphasize how a detail affects desirability, usability, originality, risk, or price.
+- **Measured.** Avoid claiming certainty where the market is subjective.
+- **Modern and clean.** No purple prose.
 
 ## Structure
 
-- **Title:** Evocative but searchable. "The Nebbiolo Enigma: Why Barolo Ages Like Nothing Else" not "An Exploration of Aging Potential in Piedmontese Nebbiolo-Based Wines"
-- **Introduction:** 2-3 sentences. Set the scene. Make the reader want to open a bottle.
-- **Headers:** H2 for major sections, H3 for subsections. Never skip levels.
-- **Paragraphs:** 3-5 sentences. Let the writing breathe.
-- **Output format:** Markdown.
+- **Title:** Clear, searchable, useful.
+- **Introduction:** 2-3 sentences that frame the collector problem.
+- **Body:** Use descriptive H2s and H3s.
+- **Conclusion:** End with a practical takeaway, not generic summary filler.
+- **Output format:** HTML.
 
-## Formatting
+## HTML Requirements
 
-- **Bold** for producer names on first mention, key terms, and regional designations
-- *Italic* for Italian terms on first use, wine names, and grape varieties when used generically
-- Use `code` style sparingly — only for technical wine data (pH, TA, alcohol %)
-- Numbered lists for rankings or sequential processes (winemaking steps, tasting order)
-- Bullet lists for non-ordered items (producer lists, grape characteristics)
+All deliverables should be valid, clean HTML suitable for publishing workflow handoff.
 
-## Wine-Specific Standards
+Required structure:
 
-- Spell out grape varieties in full on first use, then abbreviate naturally (Nebbiolo → "the grape")
-- Use Italian designations correctly: Barolo DOCG, Barbaresco DOCG, Barbera d'Asti DOCG, etc.
-- Vintage years in four digits: 2019, not '19
-- Producer names in their original Italian form: **Giacomo Conterno**, not Giacomo Conterno Winery
-- Vineyard names (*cru*) in italic: *Cannubi*, *Monfortino*, *Rabajà*
-- Temperature in both Celsius and Fahrenheit on first mention
-- Price ranges in USD with approximate conversion context
+```html
+<article>
+  <h1>Title</h1>
+  <p>Intro paragraph...</p>
+  <section>
+    <h2>Section heading</h2>
+    <p>...</p>
+  </section>
+</article>
+```
 
-## Terminology
+Preferred elements:
 
-| Use | Don't Use |
-|-----|-----------|
-| Nebbiolo | "the king of grapes" (unless quoting) |
-| DOCG | D.O.C.G. |
-| *cru* | cru (not italicized) |
-| tannin | tannic structure (unless being specific) |
-| producer | winemaker (unless referring to the person) |
-| Langhe | Langhetti or Langa (unless historically appropriate) |
-| Piedmont | Piemonte (use English form in body, Italian in wine names) |
+- `<article>` for the document wrapper
+- `<section>` for major sections
+- `<h2>` and `<h3>` in order; do not skip levels
+- `<ul>` and `<ol>` for lists
+- `<table>` only when comparison is materially helpful
+- `<blockquote>` only for attributed source quotations
+
+Do not:
+
+- inline presentational styling
+- use unnecessary `<div>` wrappers
+- paste markdown into HTML drafts
+- use heading levels for visual emphasis instead of structure
+
+## Formatting Rules
+
+- Spell out a term on first mention when needed, then use the shorter form consistently.
+- Use en dashes for ranges when appropriate.
+- Use numerals for reference numbers, calibers, years, dimensions, and prices.
+- Use sentence case for headings.
+- Link only when the source materially helps the reader or supports a claim.
+
+## Watch-Specific Standards
+
+- Distinguish clearly between **reference**, **caliber/movement**, **case material**, **dial variant**, and **complication**.
+- Be careful with terms like **rare**, **investment-grade**, **museum-quality**, and **mint**. Use only when justified.
+- If authenticity cannot be established from public evidence alone, say so.
+- Differentiate **vintage**, **neo-vintage**, and **modern** only when the cutoff is explained.
+- State when parts may have been replaced or refinished if that affects originality.
+- Avoid overgeneralizing auction results into market law.
+- When discussing value, prefer wording like **market demand**, **collector interest**, or **pricing trends** over promises of appreciation.
+
+## Sources and Evidence
+
+Preferred source types, in rough order:
+
+1. Patek Philippe official materials and archive/extract guidance
+2. Major auction house catalogs and results
+3. Reputable dealer documentation with transparent reference details
+4. Specialist watch publications with editorial standards
+5. Primary interviews or brand statements
+
+Every draft must include:
+
+- source list
+- fact-sensitive claims marked for review where needed
+- unresolved questions called out explicitly
 
 ## Content Quality Checklist
 
-- [ ] Title is evocative and searchable
-- [ ] Introduction makes you want to open a bottle
-- [ ] Wine facts are verifiable (vintages, DOCG rules, producer details)
-- [ ] Tasting notes are specific, not generic
-- [ ] Italian terms used correctly and consistently
+- [ ] Title is clear and search-friendly
+- [ ] HTML structure is clean and valid
+- [ ] Claims about references, calibers, and production context are sourced
+- [ ] Market language is careful and non-hypey
+- [ ] Condition and originality terms are used precisely
+- [ ] No unsupported authenticity claims
 - [ ] No broken links
-- [ ] Reviewed for accuracy by technical reviewer
-- [ ] SEO metadata defined (title, description, keywords)
+- [ ] Reviewed for accuracy by reviewer
+- [ ] SEO metadata defined

--- a/content/team-announcements.md
+++ b/content/team-announcements.md
@@ -1,0 +1,41 @@
+# Writing Team Announcements
+
+## Writing Team community — kickoff post (2026-04-06)
+
+Team — I’m the Editor for this cycle.
+
+We’re resetting the project around **Patek Philippe** for a **collector** audience. The working standard is the **Microsoft Writing Style Guide** adapted for watch content: clear, precise, modern, and useful. Output is **HTML**, not Markdown.
+
+I reviewed the workspace and found earlier planning documents from a different series. Those have now been replaced with a new collector-focused content plan, style guide, reviewer brief, and publishing calendar.
+
+Initial assignments:
+
+- **Writer 1**
+  - How to Read a Patek Philippe Reference Like a Collector
+  - Which Patek Philippe Complications Matter Most to Collectors?
+- **Writer 2**
+  - Buying Vintage Patek Philippe: Originality, Provenance, and the Red Flags That Matter
+
+Sprint 2 topics are also defined in the content plan:
+- Calatrava, Nautilus, Aquanaut, Golden Ellipse: How the Core Families Fit a Serious Collection
+- Archive Extracts, Service History, and Condition: How to Evaluate a Patek Before You Buy
+- Modern Patek Philippe Collecting: Which References Are Overhyped, Underrated, and Actually Interesting?
+
+Please optimize for specificity, sourcing, and collector usefulness. Avoid luxury cliche and do not turn market commentary into investment advice.
+
+## Status group — initial schedule post (2026-04-06)
+
+Initial publishing schedule is live.
+
+- **2026-04-08:** Sprint 1 outlines due
+- **2026-04-13:** Sprint 1 drafts begin moving to review
+- **2026-04-17:** Sprint 1 publish target
+- **2026-04-20:** Sprint 2 outlines due
+- **2026-05-01:** Sprint 2 publish target
+
+Priority order:
+1. How to Read a Patek Philippe Reference Like a Collector
+2. Buying Vintage Patek Philippe: Originality, Provenance, and the Red Flags That Matter
+3. Which Patek Philippe Complications Matter Most to Collectors?
+
+Reviewer brief is ready, and GitHub issues are live for each assignment.


### PR DESCRIPTION
## Summary
- add Writer 2 outline for category-fit article (#53)
- add Writer 2 outline for buying-channels article (#54)
- align GitHub tracking with the current Patek content plan and publishing calendar

## Notes
- These are outline drafts for editorial review, not full HTML article drafts yet.
- I created #53 and #54 because the current content plan listed Writer 2 assignments that did not yet have matching open issues.

Closes #53
Closes #54